### PR TITLE
Add apibara to Starknet Stack

### DIFF
--- a/starknet-stack/docker-compose.yml
+++ b/starknet-stack/docker-compose.yml
@@ -39,6 +39,24 @@ services:
       - RPC_URL=http://madara:9944
       - AMOUNT_TRANSFERED=1000000000000000
     restart: on-failure
+    depends_on:
+      - madara
+    networks:
+      - internal
+
+  apibara:
+    image: quay.io/apibara/starknet:7f00306001c1ff030ccc1babf49b880dbe6c7e0e 
+    ports:
+      - 7171:7171
+    command:
+      - start
+    environment:
+      - RPC=http://madara:9944
+      - WAIT_FOR_RPC=true
+      - RUST_LOG=warn
+    restart: on-failure
+    depends_on:
+      - madara
     networks:
       - internal
 


### PR DESCRIPTION
I added Apibara to the Starknet Stack. That image is enough to enable the integrations on Madara, e.g. if we want to invoke a webhook at every block:

* create `/path/to/filter.json` with the data filter

```json
{
  "header": { "weak": false }
}
```

 * Run `apibara-sink-webhook` from the [dna repo](https://github.com/apibara/dna).

```bash
apibara-sink-webhook --filter=/path/to/filter.json --stream-url=http://localhost:7171 --starknet --starting-block=0 --target-url=http://example.org
```


