### PR TITLE
Add Kakacet

### DIFF
--- a/starknet-stack/docker-compose.yml
+++ b/starknet-stack/docker-compose.yml
@@ -14,6 +14,25 @@ services:
     networks:
       - internal
 
+  add-accounts:
+    image: ghcr.io/the-candy-shop/starksheet-monorepo/starksheet-cairo:latest
+    command: python scripts/add_accounts.py
+    depends_on:
+      madara:
+        condition: service_healthy
+    environment:
+      RPC_URL: http://madara:9944
+      COUNT: 3
+      AMOUNT: 2
+      ACCOUNT_ADDRESS: "0x3"
+      PRIVATE_KEY: "0x00c1cf1490de1352865301bb8705143f3ef938f97fdf892f1090dcb5ac7bcd1d"
+    volumes:
+      - account-0:/app/starksheet/packages/starksheet-cairo/0
+      - account-1:/app/starksheet/packages/starksheet-cairo/1
+      - account-2:/app/starksheet/packages/starksheet-cairo/2
+    networks:
+      - internal
+
   # -------------
   # Substrate app
   # -------------
@@ -55,13 +74,14 @@ services:
     depends_on:
       madara:
         condition: service_healthy
+      add-accounts:
+        condition: service_completed_successfully
     environment:
-      ACCOUNT_ADDRESS: "0x3"
-      PRIVATE_KEY: "0x00c1cf1490de1352865301bb8705143f3ef938f97fdf892f1090dcb5ac7bcd1d"
       RPC_URL: http://madara:9944
     volumes:
       - starksheet-deployments:/app/starksheet/packages/starksheet-cairo/deployments
       - starksheet-build:/app/starksheet/packages/starksheet-cairo/build
+      - account-0:/app/starksheet/packages/starksheet-cairo
     networks:
       - internal
 
@@ -87,13 +107,14 @@ services:
     depends_on:
       madara:
         condition: service_healthy
+      add-accounts:
+        condition: service_completed_successfully
     environment:
-      ACCOUNT_ADDRESS: "0x3"
-      PRIVATE_KEY: "0x00c1cf1490de1352865301bb8705143f3ef938f97fdf892f1090dcb5ac7bcd1d"
       RPC_URL: http://madara:9944
       EVM_PRIVATE_KEY: "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
     volumes:
       - kakarot-deployments:/app/kakarot/deployments
+      - account-1:/app/kakarot
     networks:
       - internal
 
@@ -186,12 +207,13 @@ services:
     depends_on:
       madara:
         condition: service_healthy
+      add-accounts:
+        condition: service_completed_successfully
     environment:
-      ACCOUNT_ADDRESS: "0x3"
-      PRIVATE_KEY: "0x00c1cf1490de1352865301bb8705143f3ef938f97fdf892f1090dcb5ac7bcd1d"
       RPC_URL: http://madara:9944
     volumes:
       - madara-swap-deployments:/app/madara-swap/packages/contracts/deployments
+      - account-2:/app/madara-swap/packages/contracts/
     networks:
       - internal
 
@@ -266,5 +288,8 @@ volumes:
   madara-swap-deployments:
   kakasheet-broadcast:
   kakasheet-out:
+  account-0:
+  account-1:
+  account-2:
 networks:
   internal:

--- a/starknet-stack/docker-compose.yml
+++ b/starknet-stack/docker-compose.yml
@@ -105,8 +105,10 @@ services:
     entrypoint:
       - "/bin/sh"
       - "-c"
+      # First line overrides an existing .env to make sure that .env is clean even though docker volume was not cleaned
       - |
         echo "KAKAROT_ADDRESS=$(jq -r '.kakarot.address' /deployments/deployments.json)" > /deployments/.env;
+        echo "REACT_APP_KAKAROT_ADDRESS=$(jq -r '.kakarot.address' /deployments/deployments.json)" >> /deployments/.env;
         echo "PROXY_ACCOUNT_CLASS_HASH=$(jq -r '.proxy' /deployments/declarations.json)" >> /deployments/.env
     volumes:
       - kakarot-deployments:/deployments
@@ -121,7 +123,6 @@ services:
     environment:
       KAKAROT_HTTP_RPC_ADDRESS: "0.0.0.0:3030"
       STARKNET_NETWORK: http://madara:9944
-      EVM_PRIVATE_KEY: "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
       RUST_LOG: trace
     volumes:
       - kakarot-deployments:/usr/src/app
@@ -132,6 +133,22 @@ services:
     healthcheck:
       test: ["CMD", "echo", "ok"]
       interval: 5s
+
+  kakacet-front:
+    image: ghcr.io/kkrt-labs/kakacet/frontend:latest
+    ports:
+      - 3005:3000
+    environment:
+      - REACT_APP_RPC_URL=http://0.0.0.0:9944
+    volumes:
+      - kakarot-deployments:/app
+    depends_on:
+      starkcet-back:
+        condition: service_started
+      kakarot-rpc:
+        condition: service_healthy
+    networks:
+      - internal
 
   kakasheet-deployer:
     image: ghcr.io/the-candy-shop/starksheet-monorepo/starksheet-solidity:latest


### PR DESCRIPTION
# Add Kakacet

Kakacet is just another front end on top of Starkcet, that allows users to input
an EVM address for Kakarot instead of a Starknet address.
